### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sample project using [cordova geofence plugin](https://github.com/tsubik/cordova
 
 ![ionic-geofence](https://cloud.githubusercontent.com/assets/1286444/4302807/604c7c5e-3e5e-11e4-87df-99b22abffdc8.jpg)
 
-##Installation
+## Installation
 
 Use local npm packages
 
@@ -35,12 +35,12 @@ ionic platform add ios
 ionic run ios
 ```
 
-##Platforms
+## Platforms
 
 - Android
 - iOS
 
-##License
+## License
 
 This software is released under the [MIT License](https://raw.githubusercontent.com/tsubik/ionic-geofence/master/LICENSE).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
